### PR TITLE
Removing platform-dependent warning during compile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,6 +8,11 @@
     <name>CSP Minesweeper</name>
     <version>1.0.0-SNAPSHOT</version>
 
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
+
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
Removing platform dependent warning by setting source and output encoding to be UTF-8.