### PR TITLE
Use the structured compilerArgs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,9 @@
                 <configuration>
                     <source>19</source>
                     <target>19</target>
-                    <compilerArgument>--enable-preview</compilerArgument>
+                    <compilerArgs>
+                        <compilerArg>--enable-preview</compilerArg>
+                    </compilerArgs>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
Instead of unstructured compilerArgument, as former is better understood by IDEs while latter is, well, unstructured.

For example IDEA will assume no preview is enabled....